### PR TITLE
Get Zope4 compatibility.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,6 @@
 [buildout]
-extends = http://download.zope.org/Zope2/index/2.13.19/versions.cfg
 parts = test
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/4.0a6/versions-prod.cfg
 develop = .
 
 [test]
@@ -8,3 +8,8 @@ recipe = zc.recipe.testrunner
 eggs =
     five.formlib
 defaults = ['-c', '--module', 'five.formlib']
+
+[versions]
+Zope2 =
+zope.formlib =
+

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,6 +2,11 @@
 parts = test
 extends = https://raw.githubusercontent.com/zopefoundation/Zope/4.0a6/versions-prod.cfg
 develop = .
+extensions = mr.developer
+sources = sources
+sources-dir = auto-checkout-sources
+auto-checkout =
+    Zope2
 
 [test]
 recipe = zc.recipe.testrunner
@@ -9,7 +14,10 @@ eggs =
     five.formlib
 defaults = ['-c', '--module', 'five.formlib']
 
+[sources]
+Zope2 = git https://github.com/zopefoundation/Zope
+
 [versions]
 Zope2 =
-zope.formlib =
-
+mr.developer = 1.38
+zope.formlib = 4.5

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -20,4 +20,4 @@ Zope2 = git https://github.com/zopefoundation/Zope
 [versions]
 Zope2 =
 mr.developer = 1.38
-zope.formlib = 4.5
+zope.formlib = 4.4

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'zope.browsermenu',
         'zope.component',
         'zope.event',
-        'zope.formlib>=4.0',
+        'zope.formlib>=4.5',
         'zope.i18nmessageid',
         'zope.interface',
         'zope.lifecycleevent',
@@ -41,7 +41,7 @@ setup(
         'zope.publisher',
         'zope.schema',
         'ExtensionClass',
-        'Zope2>=2.13',
+        'Zope2>=2.13, <4.0a1, >=4.0a7.dev0',
     ],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'zope.browsermenu',
         'zope.component',
         'zope.event',
-        'zope.formlib>=4.5',
+        'zope.formlib>=4.4',
         'zope.i18nmessageid',
         'zope.interface',
         'zope.lifecycleevent',
@@ -41,7 +41,7 @@ setup(
         'zope.publisher',
         'zope.schema',
         'ExtensionClass',
-        'Zope2>=2.13, <4.0a1, >=4.0a7.dev0',
+        'Zope2>=4.0a7.dev0',
     ],
     zip_safe=False,
 )

--- a/src/five/formlib/tests/forms.txt
+++ b/src/five/formlib/tests/forms.txt
@@ -187,7 +187,7 @@ via and override in the zcml.  Let's ensure that that works:
   ... edittest2
   ... -----------------------------968064918930967154199105236--
   ... """, handle_errors=False)
-  HTTP/1.1 302 Moved Temporarily
+  HTTP/1.1 302 Found
   ...
   Location: http://localhost/test_folder_1_/ftf/manage_main
   ...
@@ -287,7 +287,7 @@ the form will submit correctly and create the object:
   ... unicodetest
   ... -----------------------------968064918930967154199105236--
   ... """ % (ni_hao, wo_hen_hao), handle_errors=False)
-  HTTP/1.1 302 Moved Temporarily
+  HTTP/1.1 302 Found
   ...
   Location: http://localhost/test_folder_1_/ftf/manage_main
   ...


### PR DESCRIPTION
To get the tests running some versions had to be updated, so that I used the current Zope4 checkout. This can be removed, if a new release of `Zope2 >= 4.7.dev0` was done. 

This PR restricts `five.formlib` to Zope4, but as the tests did not run before I am not sure, whether we need a release beforehand.  

Fixes #1 