### PR TITLE
replace Python 3 incompatible `zope.interface.implements` by `zope.interface.implementer`'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+* Replace Python 3 incompatible `zope.interface.implements` by `zope.interface.implementer`
 
 
 2.0 (2018-08-15)

--- a/src/five/formlib/formbase.py
+++ b/src/five/formlib/formbase.py
@@ -68,50 +68,43 @@ class AddFormBase(FiveFormlibMixin, form.AddFormBase):
     pass
 
 
-class PageForm(FormBase):
-
-    interface.implements(interfaces.IPageForm)
+@interface.implementer(interfaces.IPageForm)
+class PageForm(FormBase): pass
 
 Form = PageForm
 
 
-class PageEditForm(EditFormBase):
-
-    interface.implements(interfaces.IPageForm)
+@interface.implementer(interfaces.IPageForm)
+class PageEditForm(EditFormBase): pass
 
 EditForm = PageEditForm
 
 
-class PageDisplayForm(DisplayFormBase):
-
-    interface.implements(interfaces.IPageForm)
+@interface.implementer(interfaces.IPageForm)
+class PageDisplayForm(DisplayFormBase): pass
 
 DisplayForm = PageDisplayForm
 
 
-class PageAddForm(AddFormBase):
-
-    interface.implements(interfaces.IPageForm)
+@interface.implementer(interfaces.IPageForm)
+class PageAddForm(AddFormBase): pass
 
 AddForm = PageAddForm
 
 
+@interface.implementer(interfaces.ISubPageForm)
 class SubPageForm(FormBase):
 
     template = ViewPageTemplateFile(_SUBPAGEFORM_PATH)
 
-    interface.implements(interfaces.ISubPageForm)
 
-
+@interface.implementer(interfaces.ISubPageForm)
 class SubPageEditForm(EditFormBase):
 
     template = ViewPageTemplateFile(_SUBPAGEFORM_PATH)
 
-    interface.implements(interfaces.ISubPageForm)
 
-
+@interface.implementer(interfaces.ISubPageForm)
 class SubPageDisplayForm(DisplayFormBase):
 
     template = ViewPageTemplateFile(_SUBPAGEFORM_PATH)
-
-    interface.implements(interfaces.ISubPageForm)

--- a/src/five/formlib/tests/content.py
+++ b/src/five/formlib/tests/content.py
@@ -16,7 +16,7 @@ from AccessControl.class_init import InitializeClass
 from OFS.SimpleItem import SimpleItem
 
 from zope.i18nmessageid import MessageFactory
-from zope.interface import implements
+from zope.interface import implementer
 from zope.interface import Interface
 from zope.schema import ASCIILine
 from zope.schema import List
@@ -48,10 +48,10 @@ class IContent(Interface):
         required=False
     )
 
+@implementer(IContent)
 class Content(SimpleItem):
     """A Viewable piece of content with fields
     """
-    implements(IContent)
 
     meta_type = 'Five Formlib Test Content'
 

--- a/src/five/formlib/tests/schemacontent.py
+++ b/src/five/formlib/tests/schemacontent.py
@@ -17,7 +17,7 @@ from OFS.SimpleItem import SimpleItem
 
 from zope.formlib.widget import CustomWidgetFactory
 from zope.i18nmessageid import MessageFactory
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 from zope.schema import TextLine, Text, Object, Int, List
 
 from five.formlib.objectwidget import ObjectWidget
@@ -54,9 +54,9 @@ class IFieldContent(Interface):
         required=False
     )
 
+@implementer(IFieldContent)
 class FieldContent(SimpleItem):
     """A Viewable piece of content with fields"""
-    implements(IFieldContent)
     meta_type = 'Five FieldContent'
 
     def __init__(self, id, title):
@@ -87,8 +87,8 @@ class IComplexSchemaContent(Interface):
         description=u"The fishy object",
         required=True)
 
+@implementer(IComplexSchemaContent)
 class ComplexSchemaContent(SimpleItem):
-    implements(IComplexSchemaContent)
     meta_type = "Five ComplexSchemaContent"
 
     def __init__(self, id):


### PR DESCRIPTION
Fixes #4