### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-4.1 (unreleased)
+5.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changelog
 5.0 (unreleased)
 ----------------
 
-* Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.
-
+* Drop support for ``pkg_resources`` namespace and replace it with
+  PEP 420 native namespace.
+  Caution: This change requires to switch all packages in the `five`
+  namespace to versions using a PEP 420 namespace.
 
 4.0 (2025-01-29)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 5.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+* Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.
 
 
 4.0 (2025-01-29)

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Application Frameworks",
     ],
     keywords='zope zope5 five formlib',
-    packages=['five', 'five.formlib'],
-    package_dir={'': 'src'},
-    namespace_packages=['five'],
     include_package_data=True,
     python_requires='>=3.9',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='five.formlib',
-    version='4.1.dev0',
+    version='5.0.dev0',
     url='https://github.com/zopefoundation/five.formlib',
     license='ZPL 2.1',
     description='zope.formlib integration for Zope.',

--- a/src/five/__init__.py
+++ b/src/five/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
